### PR TITLE
Implement better command line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ Create a virtual environment and download the required libraries.
 
 ## Usage
 
-Drag an internet shortcut onto *run.bat* to create a config file (placed at *config.txt* by default) for the form. (This is equivalent to `run -c <shortcut> config.txt`.)
+Drag an internet shortcut onto *run.bat* to create a config file (placed at *config.txt* by default) for the form. (This is equivalent to `run convert <shortcut> config.txt`.)
 
-Double click *run.bat* to find and use *config.txt* in the current folder. (`run -p config.txt`) To use a different file, drag it onto *run.bat*. (`run -p <filename>`)
+Double click *run.bat* to find and use *config.txt* in the current folder. (`run process config.txt`) To use a different file, drag it onto *run.bat*. (`run process <filename>`)
 
 You can also run the following in case the program window closes immediately. Replace `<command>` with the text in `code format` found above.
 

--- a/form.py
+++ b/form.py
@@ -495,16 +495,6 @@ def config_lines_from_info(info):
     for entry in entries_from_info(info):
         yield str(entry)
 
-# Original parser
-parser = ArgumentParser(description="Automate Google Forms")
-parser.add_argument("target", default="config.txt", nargs="?",
-    help="file or url to use")
-modes = parser.add_mutually_exclusive_group()
-modes.add_argument("-p", "--process", action="store_true",
-    help="process the target config file and send the response")
-modes.add_argument("-c", "--convert", metavar="URL",
-    help="convert the form at the url into a config file at target")
-
 # Better parser that allows you to specify converter origin type.
 # (Whether it's a file or a shortcut)
 better = ArgumentParser(description="Automate Google Forms (better)")

--- a/form.py
+++ b/form.py
@@ -619,6 +619,11 @@ def convert(
         print_("Form cannot be converted (missing beautifulsoup4 library)")
         sys.exit(3)
 
+    # Get the origin mode. This is before checking target because origin comes
+    # before target in the command: `convert origin [target]`
+    if mode is None:
+        mode = get_convert_mode(origin)
+
     # Check if config file can be written to
     try:
         with open(target) as file:
@@ -637,9 +642,6 @@ def convert(
             print_("File will be overwritten")
         elif not should_overwrite:
             raise ValueError(f"File exists and is not empty: {target}")
-
-    if mode is None:
-        mode = get_convert_mode(origin)
 
     print_(f"Getting form HTML source [{mode}]: {origin}")
     text = get_html_from_convert(origin, mode)

--- a/form.py
+++ b/form.py
@@ -600,7 +600,7 @@ def process(target="config.txt", *, command_line=False, should_submit=None):
 # exist.
 def convert(
     origin, target="config.txt", mode=None,
-    *, command_line=False, should_overwrite=False,
+    *, command_line=False, should_overwrite=None,
 ):
     if not command_line:
         print_ = lambda *args, **kwargs: None

--- a/form.py
+++ b/form.py
@@ -698,5 +698,5 @@ if __name__ == "__main__":
         sys.exit(4)
     finally:
         if simple_run:
-            with suppress(BaseException):
+            with suppress(KeyboardInterrupt):
                 input("Press enter to close the program...")

--- a/form.py
+++ b/form.py
@@ -220,14 +220,14 @@ def to_form_url(string):
         return string.removesuffix("viewform") + "formResponse"
     raise ValueError(f"String cannot be converted into form link: {string}")
 
-def url_from_shortcut(shortcut):
+def url_from_shortcut(filename):
     """
     Return the URL from an internet shortcut.
     """
-    parser = ConfigParser()
-    with open(shortcut) as file:  # The file must exist
-        parser.read_file(file)
-    return parser["InternetShortcut"]["URL"]
+    shortcut = ConfigParser()
+    with open(filename) as file:  # The file must exist
+        shortcut.read_file(file)
+    return shortcut["InternetShortcut"]["URL"]
 
 def to_normal_form_url(string):
     """
@@ -457,8 +457,8 @@ def config_lines_from_info(info):
 
 # Better parser that allows you to specify converter origin type.
 # (Whether it's a file or a shortcut)
-better = ArgumentParser(description="Automate Google Forms")
-subparsers = better.add_subparsers(dest="command", required=True,
+parser = ArgumentParser(description="Automate Google Forms")
+subparsers = parser.add_subparsers(dest="command", required=True,
     description="All commands form.py supports")
 
 # form process ...
@@ -669,7 +669,7 @@ def is_simple_run(argv):
     return False
 
 # Pass in sys.argv[1:]. Assume is_simple_run(argv) is True. Returns converted
-# arguments that can be passed into better.parse_args.
+# arguments that can be passed into parser.parse_args.
 def convert_simple_argv(argv):
     if not argv:  # Double click
         return ["process", "config.txt"]
@@ -689,7 +689,7 @@ if __name__ == "__main__":
     try:
         if simple_run:
             argv = convert_simple_argv(argv)
-        args = better.parse_args(argv)
+        args = parser.parse_args(argv)
         main(args)
     except Exception:  # This won't catch Ctrl+C or sys.exit
         if not simple_run:

--- a/form.py
+++ b/form.py
@@ -457,7 +457,7 @@ def config_lines_from_info(info):
 
 # Better parser that allows you to specify converter origin type.
 # (Whether it's a file or a shortcut)
-better = ArgumentParser(description="Automate Google Forms (better)")
+better = ArgumentParser(description="Automate Google Forms")
 subparsers = better.add_subparsers(dest="command", required=True,
     description="All commands form.py supports")
 

--- a/form.py
+++ b/form.py
@@ -700,11 +700,10 @@ def main(args=None):
     if args is None:
         args = parse_arguments()
     if args.command in "process p".split():
-        process(args.target, command_line=True)
-    elif args.command in "convert c".split():
-        convert(args.origin, args.target, args.mode, command_line=True)
-    else:
-        raise ValueError(f"Unknown command: {args.command}")
+        return process(args.target, command_line=True)
+    if args.command in "convert c".split():
+        return convert(args.origin, args.target, args.mode, command_line=True)
+    raise ValueError(f"Unknown command: {args.command}")
 
 if __name__ == "__main__":
     # Not wrapped by try-finally as the user is likely running this from the

--- a/form.py
+++ b/form.py
@@ -531,13 +531,15 @@ def get_target_command(target):
 
 # Return convert mode that could be used on origin
 def get_convert_mode(origin):
-    with suppress(FileNotFoundError, OSError, ConfigError, KeyError):
-        url_from_shortcut(origin)
-        return "shortcut"
     with suppress(ValueError):
         to_form_url(origin)
         return "url"
-    with suppress(FileNotFoundError, OSError):  # Put after shortcut
+    # Put after checking URL so we can use FileNotFoundError instead of OSError
+    with suppress(FileNotFoundError, ConfigError, KeyError):
+        url_from_shortcut(origin)
+        return "shortcut"
+    # Put after shortcut because "file" includes "shortcut"
+    with suppress(FileNotFoundError):
         open(origin).close()
         return "file"
     raise ValueError(f"Origin's mode couldn't be detected: {origin}")

--- a/form.py
+++ b/form.py
@@ -516,11 +516,14 @@ def get_target_command(target):
     except ValueError:
         return "process"
 
-    if mode == "file" and not target.endswith(".html"):
-        # Assume that unless the file is a config file if it isn't .html
-        return "process"
-    else:
+    if mode != "file":
         return "convert"
+
+    # If the target ends with .html, it could be a downloaded form
+    if target.endswith(".html"):
+        return "convert"
+    else:
+        return "process"
 
 # Return convert mode that could be used on origin
 def get_convert_mode(origin):
@@ -617,7 +620,6 @@ def convert(
                 raise FileNotFoundError  # File can be written to
     except FileNotFoundError:
         print_(f"Target file doesn't exist or is empty: {target}")
-
     # File exists and not empty
     else:
         if command_line and should_overwrite is None:

--- a/form.py
+++ b/form.py
@@ -522,11 +522,14 @@ converter.add_argument("target", default="config.txt", nargs="?",
     help="target file to write converted config to")
 
 modes = converter.add_mutually_exclusive_group()
-modes.add_argument("-u", "--url", action="store_true",
+modes.add_argument("-u", "--url", const="url",
+    dest="mode", action="store_const",
     help="assume origin is a url")
-modes.add_argument("-f", "--file", action="store_true",
+modes.add_argument("-f", "--file",  const="file",
+    dest="mode", action="store_const",
     help="assume origin is an html file")
-modes.add_argument("-s", "--shortcut", action="store_true",
+modes.add_argument("-s", "--shortcut", const="shortcut",
+    dest="mode", action="store_const",
     help="assume origin is a shortcut to a url")
 
 # Get and convert the form HTML

--- a/form.py
+++ b/form.py
@@ -225,7 +225,8 @@ def url_from_shortcut(shortcut):
     Return the URL from an internet shortcut.
     """
     parser = ConfigParser()
-    parser.read(shortcut)
+    with open(shortcut) as file:  # The file must exist
+        parser.read_file(file)
     return parser["InternetShortcut"]["URL"]
 
 def to_normal_form_url(string):

--- a/form.py
+++ b/form.py
@@ -1,3 +1,7 @@
+import json
+import sys
+import traceback
+
 from argparse import ArgumentParser
 from collections import namedtuple
 from configparser import ConfigParser
@@ -329,7 +333,6 @@ def question_type(question):
 
 # Return body > script (FB_PUBLIC_LOAD_DATA_)
 def form_json_data(soup):
-    import json
     script = soup.select("body>script")[0].contents[0]
     data = script.partition("=")[2].rstrip().removesuffix(";")
     return json.loads(data)
@@ -661,8 +664,6 @@ if __name__ == "__main__":
     except SystemExit:
         raise
     except Exception:
-        import traceback
-        import sys
         traceback.print_exc()
         sys.exit(4)
     finally:

--- a/form.py
+++ b/form.py
@@ -563,7 +563,7 @@ def get_target_command(target):
     with suppress(ValueError):
         to_form_url(target)
         return "convert"
-    if args.target.endswith(".html"):  # Could be a downloaded form
+    if target.endswith(".html"):  # Could be a downloaded form
         return "convert"
     return "process"
 

--- a/form.py
+++ b/form.py
@@ -512,7 +512,7 @@ def get_html_from_convert(origin, mode):
 def get_target_command(target):
     try:
         # Raises error if not convertable (get_convert_mode)
-        mode = get_convert_mode(origin)
+        mode = get_convert_mode(target)
     except ValueError:
         return "process"
 

--- a/form.py
+++ b/form.py
@@ -489,6 +489,7 @@ def config_lines_from_info(info):
     for entry in entries_from_info(info):
         yield str(entry)
 
+# Original parser
 parser = ArgumentParser(description="Automate Google Forms")
 parser.add_argument("target", default="config.txt", nargs="?",
     help="file or url to use")
@@ -497,6 +498,36 @@ modes.add_argument("-p", "--process", action="store_true",
     help="process the target config file and send the response")
 modes.add_argument("-c", "--convert", metavar="URL",
     help="convert the form at the url into a config file at target")
+
+# Better parser that allows you to specify converter origin type.
+# (Whether it's a file or a shortcut)
+better = ArgumentParser(description="Automate Google Forms (better)")
+subparsers = better.add_subparsers(dest="command", required=True,
+    description="All commands form.py supports")
+
+# form process ...
+processor = subparsers.add_parser("process", aliases=["p"],
+    help="process config file and send form response",
+    description="Process config file and send form response")
+processor.add_argument("target", default="config.txt", nargs="?",
+    help="file to use process config from")
+
+# form convert ...
+converter = subparsers.add_parser("convert", aliases=["c"],
+    help="convert form into config file",
+    description="Convert form into config file")
+converter.add_argument("origin",
+    help="origin file / url to convert from")
+converter.add_argument("target", default="config.txt", nargs="?",
+    help="target file to write converted config to")
+
+modes = converter.add_mutually_exclusive_group()
+modes.add_argument("-u", "--url", action="store_true",
+    help="assume origin is a url")
+modes.add_argument("-f", "--file", action="store_true",
+    help="assume origin is an html file")
+modes.add_argument("-s", "--shortcut", action="store_true",
+    help="assume origin is a shortcut to a url")
 
 # Get and convert the form HTML
 def get_html_from_convert(convert):


### PR DESCRIPTION
Use subparsers instead of optional arguments. Simple invocations such as  double clicking (0 arguments) or drag and dropping (1 argument) are still supported.